### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ jobs:
           cache: yarn
       # In CI, yarn 2 automatically fails CI if lockfile will change
       - name: Run Install
-        run: yarn install
+        run: yarn
 
   test:
     name: Run Tests
@@ -25,7 +25,7 @@ jobs:
           node-version: 14.x
           cache: yarn
       - name: install
-        run: yarn install --immutable
+        run: yarn --immutable
       - name: test
         run: yarn test
 
@@ -39,7 +39,7 @@ jobs:
           node-version: 14.x
           cache: yarn
       - name: install
-        run: yarn install --immutable
+        run: yarn --immutable
       - name: lint
         run: yarn lint
 
@@ -53,6 +53,6 @@ jobs:
           node-version: 14.x
           cache: yarn
       - name: install
-        run: yarn install --immutable
+        run: yarn --immutable
       - name: format-check
         run: yarn format:check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+# Workflow runs after release is published in GH UI
+# Currently no automated version checking
+# Be sure to bump pjson version & changelog before creating a new release
+
+name: "Publish After Release"
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: yarn
+      - run: yarn
+      - run: yarn test
+      - run: npm publish
+          env:
+            NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,4 +20,4 @@ jobs:
       - run: yarn test
       - run: npm publish
           env:
-            NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+            NPM_REGISTRY_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.0] - 2022-01-25
+
+### Added
+
+- Initial release of deptrics beta API


### PR DESCRIPTION
Automatically publish packages to npm as a result of creating a GH release. 

No automation in place for checking package version, changelog, etc, so that should all be done manually for now.