### PR TITLE
adds tests and documentation for package version callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A package to report dependency metrics. Currently relies on output from `yarn in
 ### `getPackageVersionMetrics`
 
 `getPackageVersionMetrics(obj)`,
-`getPackageVersionMetrics({packageName, version})`
+`getPackageVersionMetrics({packageName, version, additionalMetricCalculation, getPackageVersionInfo})`
 
 #### Parameters
 
@@ -41,9 +41,25 @@ A package to report dependency metrics. Currently relies on output from `yarn in
 - `packageName`: Name of the npm package to retrieve metrics for
 - `version`: Package version to calculate health metrics for
 - `additionalMetricCalculation`: A function which is passed the result of
-  `yarn info`, and whose return value is spread into the return value of this
+  `getPackageVersionInfo`, and whose return value is spread into the return value of this
   function. Allows for customization of metrics without needing to call
-  `yarn info` again.
+  `getPackageVersionInfo` again.
+- `getPackageVersionInfo`: A function which is passed the `packageName` and whose return value is a json string:
+```
+{
+  "versions": [
+    "0.0.1",
+    "0.2.0",
+    ...
+  ],
+  "time": [
+   "0.0.1": "2013-07-06T00:54:44.444Z",
+   "0.2.0": "2013-07-17T04:04:55.944Z",
+   ...
+  ],
+  ...otherPackageData
+}
+```
 
 #### Return Value
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A package to report dependency metrics. Currently relies on output from `yarn in
   `getPackageVersionInfo`, and whose return value is spread into the return value of this
   function. Allows for customization of metrics without needing to call
   `getPackageVersionInfo` again.
-- `getPackageVersionInfo`: A function which is passed the `packageName` and whose return value is a json string:
+- `getPackageVersionInfo`: A function which is passed the `packageName` and whose return value is an object with `versions` and `time` data
 ```
 {
   "versions": [

--- a/src/__tests__/package-methods.test.js
+++ b/src/__tests__/package-methods.test.js
@@ -14,14 +14,6 @@ const mockGetPackageVersionInfo = () => ({
   },
 });
 
-const mockGetPackageVersionInfoNoVersions = () => ({
-  time: {},
-});
-
-const mockGetPackageVersionInfoNoTime = () => ({
-  versions: {},
-});
-
 describe("getPackageVersionMetrics", () => {
   it("Returns dependency metrics", () => {
     const {
@@ -82,7 +74,7 @@ describe("getPackageVersionMetrics", () => {
       getPackageVersionMetrics({
         packageName: "foo",
         version: "1.2.0",
-        getPackageVersionInfo: mockGetPackageVersionInfoNoTime,
+        getPackageVersionInfo: () => ({ versions: {} }),
       });
     }).toThrow(
       "`time` property not found when calling `getPackageVersionInfo` from `getPackageVersionMetrics`"
@@ -91,7 +83,7 @@ describe("getPackageVersionMetrics", () => {
       getPackageVersionMetrics({
         packageName: "foo",
         version: "1.2.0",
-        getPackageVersionInfo: mockGetPackageVersionInfoNoVersions,
+        getPackageVersionInfo: () => ({ time: {} }),
       });
     }).toThrow(
       "`versions` property not found when calling `getPackageVersionInfo` from `getPackageVersionMetrics`"

--- a/src/__tests__/package-methods.test.js
+++ b/src/__tests__/package-methods.test.js
@@ -14,6 +14,14 @@ const mockGetPackageVersionInfo = () => ({
   },
 });
 
+const mockGetPackageVersionInfoNoVersions = () => ({
+  time: {},
+});
+
+const mockGetPackageVersionInfoNoTime = () => ({
+  versions: {},
+});
+
 describe("getPackageVersionMetrics", () => {
   it("Returns dependency metrics", () => {
     const {
@@ -68,6 +76,26 @@ describe("getPackageVersionMetrics", () => {
     });
 
     expect(extraKey).toBe(true);
+  });
+  it("Errors when required fields are missing from getPackageVersionInfo", () => {
+    expect(() => {
+      getPackageVersionMetrics({
+        packageName: "foo",
+        version: "1.2.0",
+        getPackageVersionInfo: mockGetPackageVersionInfoNoTime,
+      });
+    }).toThrow(
+      "`time` property not found when calling `getPackageVersionInfo` from `getPackageVersionMetrics`"
+    );
+    expect(() => {
+      getPackageVersionMetrics({
+        packageName: "foo",
+        version: "1.2.0",
+        getPackageVersionInfo: mockGetPackageVersionInfoNoVersions,
+      });
+    }).toThrow(
+      "`versions` property not found when calling `getPackageVersionInfo` from `getPackageVersionMetrics`"
+    );
   });
 });
 

--- a/src/package-methods.js
+++ b/src/package-methods.js
@@ -48,6 +48,20 @@ const getAverageTimeBetweenMajorReleases = (versions, times) => {
   return calculateAverageTimeBetweenTimestamps(majorReleaseTimes);
 };
 
+// validate the date returned from this callback has required fields in expected format
+const validatePackageVersionInfo = (info) => {
+  if (!info.versions || info.versions.length === 0) {
+    throw new Error(
+      "`versions` property not found when calling `getPackageVersionInfo` from `getPackageVersionMetrics`"
+    );
+  }
+  if (!info.time) {
+    throw new Error(
+      "`time` property not found when calling `getPackageVersionInfo` from `getPackageVersionMetrics`"
+    );
+  }
+};
+
 // function designed to be called for a consuming app / library
 // i.e. what does using this version of this package
 // mean for our dependency health
@@ -57,8 +71,10 @@ const getPackageVersionMetrics = ({
   additionalMetricCalculation = () => {},
   getPackageVersionInfo = getYarnPackageInfo,
 }) => {
-  const { versions, time, ...others } = getPackageVersionInfo({ packageName });
+  const packageVersionInfo = getPackageVersionInfo({ packageName });
+  validatePackageVersionInfo(packageVersionInfo);
 
+  const { versions, time, ...others } = packageVersionInfo;
   const mostRecentVersion = versions[versions.length - 1];
 
   const versionSequenceNumberDistance = calculateVersionSequenceNumberDistance(


### PR DESCRIPTION
Adds validation and tests for properties `versions` and `time` to be supplied by the `getPackageVersionInfo` callback.

Adds documentation in the readme outlining the required fields for `getPackageVersionInfo`

fixes #2 
